### PR TITLE
Prefix with function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class LambdaWarmup {
       set(service, `resources.Resources[${ruleId}]`, ruleResource);
 
       targetsChunk.forEach(target => {
-        const permissionId = `${ruleId}${target.Id}Permission`;
+        const permissionId = `${target.Id}${ruleId}Permission`;
         const permissionResource = {
           Type: 'AWS::Lambda::Permission',
           Properties: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-warmup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Serverless plugin that creates CloudWatch rule to keep your lambdas warm",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^4.0.1",
-    "nyc": "^11.3.0",
+    "nyc": "^11.4.1",
     "sinon": "^4.1.1"
   },
   "dependencies": {

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -128,7 +128,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 ]
               }
             },
-            LambdaWarmupEventsRule1Function1LambdaFunctionSchedulePermission: {
+            Function1LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Type: 'AWS::Lambda::Permission',
               Properties: {
                 Action: 'lambda:InvokeFunction',
@@ -141,7 +141,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule1Function2LambdaFunctionSchedulePermission: {
+            Function2LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Type: 'AWS::Lambda::Permission',
               Properties: {
                 Action: 'lambda:InvokeFunction',
@@ -190,7 +190,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 ]
               }
             },
-            LambdaWarmupEventsRule1Function1LambdaFunctionSchedulePermission: {
+            Function1LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Type: 'AWS::Lambda::Permission',
               Properties: {
                 Action: 'lambda:InvokeFunction',
@@ -337,7 +337,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 ]
               }
             },
-            LambdaWarmupEventsRule1Function1LambdaFunctionSchedulePermission: {
+            Function1LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function1LambdaFunction', 'Arn']
@@ -347,7 +347,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule1Function2LambdaFunctionSchedulePermission: {
+            Function2LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function2LambdaFunction', 'Arn']
@@ -357,7 +357,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule1Function3LambdaFunctionSchedulePermission: {
+            Function3LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function3LambdaFunction', 'Arn']
@@ -367,7 +367,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule1Function4LambdaFunctionSchedulePermission: {
+            Function4LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function4LambdaFunction', 'Arn']
@@ -377,7 +377,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule1Function5LambdaFunctionSchedulePermission: {
+            Function5LambdaFunctionScheduleLambdaWarmupEventsRule1Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function5LambdaFunction', 'Arn']
@@ -387,7 +387,7 @@ describe('serverless-plugin-lambda-warmup', function() {
                 }
               }
             },
-            LambdaWarmupEventsRule2Function6LambdaFunctionSchedulePermission: {
+            Function6LambdaFunctionScheduleLambdaWarmupEventsRule2Permission: {
               Properties: {
                 FunctionName: {
                   'Fn::GetAtt': ['Function6LambdaFunction', 'Arn']


### PR DESCRIPTION
This follows sort of convention with Serverless, which is to make the resource name start with the function name. It will make it easier to determine which function this resource is associated with (used in stack splitting)